### PR TITLE
BaseTools: Fixed the multiple pairs brackets issue in GenFv

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -3559,7 +3559,7 @@ Returns:
       }
 
       // Machine type is LOONGARCH64, set a flag so LoongArch64 reset vector processed.
-      if ((MachineType == EFI_IMAGE_MACHINE_LOONGARCH64)) {
+      if (MachineType == EFI_IMAGE_MACHINE_LOONGARCH64) {
         VerboseMsg("Located LoongArch64 SEC core in child FV");
         mLoongArch = TRUE;
       }
@@ -3721,7 +3721,7 @@ Returns:
       mRiscV = TRUE;
     }
 
-    if ( (ImageContext.Machine == EFI_IMAGE_MACHINE_LOONGARCH64) ) {
+    if (ImageContext.Machine == EFI_IMAGE_MACHINE_LOONGARCH64) {
       mLoongArch = TRUE;
     }
 
@@ -4002,7 +4002,7 @@ Returns:
       mArm = TRUE;
     }
 
-    if ( (ImageContext.Machine == EFI_IMAGE_MACHINE_LOONGARCH64) ) {
+    if (ImageContext.Machine == EFI_IMAGE_MACHINE_LOONGARCH64) {
       mLoongArch = TRUE;
     }
 


### PR DESCRIPTION
If operation Werro is turned on when compiling BaseTools, the multi-brackets warning will be reported. This issue is comes from on of the LoongArch enabled patche. Removed extra pairs brackets to fix it.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Chao Li <lichao@loongson.cn>