### PR TITLE
BaseTools: Fixed the multiple pairs brackets issue in GenFv

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -102,6 +102,12 @@ F: */RiscV64/
 M: Sunil V L <sunilvl@ventanamicro.com> [vlsunil]
 R: Daniel Schaefer <git@danielschaefer.me> [JohnAZoidberg]
 
+LOONGARCH64
+F: */LoongArch64/
+M: Chao Li <lichao@loongson.cn> [kilaterlee]
+M: Baoqi Zhang <zhangbaoqi@loongson.cn> [zhangbaoqi-ls]
+R: Dongyan Qian <qiandongyan@loongson.cn> [MarsDoge]
+
 EDK II Continuous Integration:
 ------------------------------
 .azurepipelines/


### PR DESCRIPTION
If operation Werro is turned on when compiling BaseTools, the multi-brackets warning will be reported. This issue is comes from on of the LoongArch enabled patche. Removed extra pairs brackets to fix it.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Chao Li <lichao@loongson.cn>